### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with PostHog. Create annotations and manage projects directly through Claude Desktop!
 
+<a href="https://glama.ai/mcp/servers/zkqzx42bi8">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/zkqzx42bi8/badge" alt="PostHog Server MCP server" />
+</a>
+
 ## Features 🚀
 
 - **List Projects**: View all available PostHog projects in your organization
@@ -78,7 +82,6 @@ Using the Project ID you get from the list of projects, ask Claude:
 
 ```
 "Create a PostHog annotation in project 53497 saying 'Deployed v1.2.3'"
-
 ```
 
 or with a specific date:


### PR DESCRIPTION
This PR adds a badge for the [PostHog MCP Server](https://glama.ai/mcp/servers/zkqzx42bi8) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zkqzx42bi8">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/zkqzx42bi8/badge" alt="PostHog Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.